### PR TITLE
fix: Return numeric values in element rect response

### DIFF
--- a/server/lib/src/handler/get_rect.dart
+++ b/server/lib/src/handler/get_rect.dart
@@ -27,10 +27,10 @@ class GetRectHandler extends RequestHandler {
 
     Rect rect = ElementHelper.getElementBounds(element.by);
     return AppiumResponse(sessionId, {
-      "x": rect.left.toStringAsFixed(0),
-      "y": rect.top.toStringAsFixed(0),
-      "height": rect.height.toStringAsFixed(0),
-      "width": rect.width.toStringAsFixed(0)
+      "x": rect.left.round(),
+      "y": rect.top.round(),
+      "height": rect.height.round(),
+      "width": rect.width.round()
     });
   }
 }


### PR DESCRIPTION
ensure element rect returns numeric values instead of strings. This was causing problems earlier when trying to get the location from the python client.